### PR TITLE
Add log decode rules. Cannot restore a hotpot module without these

### DIFF
--- a/backup/moodle2/restore_hotpot_activity_task.class.php
+++ b/backup/moodle2/restore_hotpot_activity_task.class.php
@@ -66,4 +66,41 @@ class restore_hotpot_activity_task extends restore_activity_task {
             new restore_decode_rule('HOTPOTINDEX', '/mod/hotpot/index.php?id=$1', 'course')
         );
     }
+
+    /**
+     * Define the restore log rules that will be applied
+     * by the {@link restore_logs_processor} when restoring
+     * hotpot logs. It must return one array
+     * of {@link restore_log_rule} objects
+     */
+    static public function define_restore_log_rules() {
+        $rules = array();
+
+        $rules[] = new restore_log_rule('hotpot', 'attempt', 'view.php?id={course_module}', '{hotpot}');
+        $rules[] = new restore_log_rule('hotpot', 'report', 'report.php?id={course_module}', '{hotpot}');
+        $rules[] = new restore_log_rule('hotpot', 'review', 'view.php?id={course_module}', '{hotpot}');
+        $rules[] = new restore_log_rule('hotpot', 'submit', 'view.php?id={course_module}', '{hotpot}');
+        $rules[] = new restore_log_rule('hotpot', 'view', 'view.php?id={course_module}', '{hotpot}');
+
+        return $rules;
+    }
+
+    /**
+     * Define the restore log rules that will be applied
+     * by the {@link restore_logs_processor} when restoring
+     * course logs. It must return one array
+     * of {@link restore_log_rule} objects
+     *
+     * Note this rules are applied when restoring course logs
+     * by the restore final task, but are defined here at
+     * activity level. All them are rules not linked to any module instance (cmid = 0)
+     */
+    static public function define_restore_log_rules_for_course() {
+        $rules = array();
+
+        $rules[] = new restore_log_rule('hotpot', 'index', 'index.php?id={course}', null);
+
+        return $rules;
+    }
+
 }


### PR DESCRIPTION
The restore activity task is missing decode rules for logs. This causes any restore of a hotpot module to fail.

This change adds the decode rules for all the known add_to_log entries hotpot adds.
