### PR TITLE
Hotpot sub-plugin versions for PHPUnit test

### DIFF
--- a/attempt/hp/version.php
+++ b/attempt/hp/version.php
@@ -1,0 +1,32 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version
+ *
+ * @package    hotpotattempt
+ * @subpackage hp
+ * @copyright  2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotattempt_hp';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;

--- a/attempt/html/version.php
+++ b/attempt/html/version.php
@@ -1,0 +1,32 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version
+ *
+ * @package    hotpotattempt
+ * @subpackage html
+ * @copyright  2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotattempt_html';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;

--- a/attempt/qedoc/version.php
+++ b/attempt/qedoc/version.php
@@ -1,0 +1,32 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version
+ *
+ * @package    hotpotattempt
+ * @subpackage qedoc
+ * @copyright  2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotattempt_qedoc';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;

--- a/report/analysis/version.php
+++ b/report/analysis/version.php
@@ -1,0 +1,33 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Hotpot report version
+ *
+ * @package    hotpotreport
+ * @subpackage analysis
+ * @copyright  2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotreport_analysis';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;
+

--- a/report/clicktrail/version.php
+++ b/report/clicktrail/version.php
@@ -1,0 +1,32 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Hotpot report version
+ *
+ * @package    hotpotreport
+ * @subpackage clicktrail
+ * @copyright  2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotreport_clicktrail';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;

--- a/report/overview/version.php
+++ b/report/overview/version.php
@@ -1,0 +1,32 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Hotpot report version
+ *
+ * @package    hotpotreport
+ * @subpackage overview
+ * @copyright  2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotreport_overview';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;

--- a/report/responses/version.php
+++ b/report/responses/version.php
@@ -1,0 +1,32 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Hotpot report version
+ *
+ * @package    hotpotreport
+ * @subpackage responses
+ * @copyright  2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotreport_responses';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;

--- a/report/scores/version.php
+++ b/report/scores/version.php
@@ -1,0 +1,32 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Hotpot report version
+ *
+ * @package    hotpotreport
+ * @subpackage scores
+ * @copyright  2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotreport_scores';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;

--- a/source/hp/version.php
+++ b/source/hp/version.php
@@ -1,0 +1,32 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Hotpot source version
+ *
+ * @package    hotpotsource
+ * @subpackage hp
+ * @copyright  2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotsource_hp';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;

--- a/source/html/version.php
+++ b/source/html/version.php
@@ -1,0 +1,32 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Hotpot source version
+ *
+ * @package    hotpotsource
+ * @subpackage html
+ * @copyright 2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotsource_html';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;

--- a/source/qedoc/version.php
+++ b/source/qedoc/version.php
@@ -1,0 +1,32 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Hotpot source version
+ *
+ * @package    hotpotsource
+ * @subpackage qedoc
+ * @copyright 2015 Gordon Bateson <gordon.bateson@gmail.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') or die();
+
+$plugin->component = 'hotpotsource_qedoc';
+$plugin->requires  = 2010112400;
+$plugin->dependencies = array('mod_hotpot' => 2015012057)
+$plugin->version   = 2015012057;


### PR DESCRIPTION
The `core_plugin_manager_testcase` test in `lib/tests/plugin_manager_test.php` will fail when the hotpot sub-plugins do not have `version.php` information. This patch works with 2.8 and at least as far back as Moodle 2.1, and the clone to `$module` is not needed (i.e. `$plugin` is sufficient, similar to other sub-plugins such as quiz reports). The dependencies property is safely ignored in earlier versions, and cron and maturity are not really needed. See #2 for a similar patch. Either will make me happy :grinning: 
