### PR TITLE
Remove unused cron config option

### DIFF
--- a/lang/en/hotpot.php
+++ b/lang/en/hotpot.php
@@ -53,7 +53,6 @@ $string['hotpot:view'] = 'View the entry page of a HotPot activity';
 //
 $string['configbodystyles'] = 'By default, Moodle theme styles will override HotPot activity styles. However, for any styles selected here, the HotPot activity styles will be given priority over the Moodle theme styles.';
 $string['configenablecache'] = 'Maintaining a cache of HotPot quizzes can dramatically speed up the delivery of quizzes to the students.';
-$string['configenablecron'] = 'Specify the hours in your time zone at which the HotPot cron script may run';
 $string['configenablemymoodle'] = 'This settings controls whether HotPots are listed on the MyMoodle page or not';
 $string['configenableobfuscate'] = 'Obfuscating the javascript code to insert media players makes it more difficult to determine the media file name and guess what the file contains.';
 $string['configenableswf'] = 'Allow embedding of SWF files in HotPot activities. If enabled, this setting overrides filter_mediaplugin_enable_swf.';
@@ -177,7 +176,6 @@ $string['deleteattempts'] = 'Delete attempts';
 $string['detailsrecords'] = 'HotPot details records';
 $string['duration'] = 'Duration';
 $string['enablecache'] = 'Enable HotPot cache';
-$string['enablecron'] = 'Enable HotPot cron';
 $string['enablemymoodle'] = 'Show HotPots on MyMoodle';
 $string['enableobfuscate'] = 'Enable obfuscation of media player code';
 $string['enableswf'] = 'Allow embedding of SWF files in HotPot activities';

--- a/settings.php
+++ b/settings.php
@@ -47,21 +47,6 @@ $settings->add(
     new admin_setting_configcheckbox('hotpot_enablecache', get_string('enablecache', 'mod_hotpot'), get_string('configenablecache', 'mod_hotpot').' '.$link, 1)
 );
 
-// restrict cron job to certain hours of the day (default=never)
-$timezone = get_user_timezone_offset();
-if (abs($timezone) > 13) {
-    $timezone = 0;
-} else if ($timezone>0) {
-    $timezone = $timezone - 24;
-}
-$options = array();
-for ($i=0; $i<=23; $i++) {
-    $options[($i - $timezone) % 24] = gmdate('H:i', $i * HOURSECS);
-}
-$settings->add(
-    new admin_setting_configmultiselect('hotpot_enablecron', get_string('enablecron', 'mod_hotpot'), get_string('configenablecron', 'mod_hotpot'), array(), $options)
-);
-
 // enable embedding of swf media objects inhotpot quizzes (default=1)
 $settings->add(
     new admin_setting_configcheckbox('hotpot_enableswf', get_string('enableswf', 'mod_hotpot'), get_string('configenableswf', 'mod_hotpot'), 1)
@@ -105,4 +90,4 @@ $setting = new admin_setting_configtext('hotpot_maxeventlength', get_string('max
 $setting->set_updatedcallback('hotpot_refresh_events');
 $settings->add($setting);
 
-unset($i, $link, $options, $setting, $str, $timezone, $url);
+unset($i, $link, $options, $setting, $str, $url);


### PR DESCRIPTION
This conflicts with Moodle 2.9's timezone changes, and is not used anywhere in the code.
If it was ever needed, Moodle tasks would seem more appropriate anyway!

```
get_user_timezone_offset() is deprecated, use PHP DateTimeZone instead
line 53 of /lib/deprecatedlib.php: call to debugging()
line 51 of /mod/hotpot/settings.php: call to get_user_timezone_offset()
line 89 of /lib/classes/plugininfo/mod.php: call to include()
line 45 of /admin/settings/plugins.php: call to core\plugininfo\mod->load_settings()
line 6730 of /lib/adminlib.php: call to require()
line 532 of /admin/index.php: call to admin_get_root()
```
