### PR TITLE
Fix installation errors

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,8 +29,8 @@
 // prevent direct access to this script
 defined('MOODLE_INTERNAL') || die();
 
-if (floatval($GLOBALS['CFG']->release) <= 2.6) {
-    $plugin = new stdClass();
+if (empty($plugin)) {
+	$plugin = new StdClass();
 }
 
 $plugin->cron      = 0;
@@ -40,6 +40,4 @@ $plugin->requires  = 2010112400;      // Moodle 2.0
 $plugin->release   = '2015.04.12 (66)';
 $plugin->version   = 2015041266;
 
-if (floatval($GLOBALS['CFG']->release) <= 2.6) {
-    $module = clone($plugin);
-}
+$module = clone($plugin);


### PR DESCRIPTION
When you install Moodle you get this:

```
Notice: Undefined property: stdClass::$release in /vagrant/moodle/mod/hotpot/version.php on line 43

Call Stack:
    0.0003     245816   1. {main}() /vagrant/moodle/admin/tool/phpunit/cli/util.php:0
    0.0105    1273472   2. require('/vagrant/moodle/lib/phpunit/bootstrap.php') /vagrant/moodle/admin/tool/phpunit/cli/util.php:83
    0.0402    4374016   3. require('/vagrant/moodle/lib/setup.php') /vagrant/moodle/lib/phpunit/bootstrap.php:227
    0.3082   20394872   4. phpunit_util::initialise_cfg() /vagrant/moodle/lib/setup.php:632
    0.3130   20886944   5. core_component::get_all_versions_hash() /vagrant/moodle/lib/phpunit/classes/util.php:83
    0.3207   20931872   6. include('/vagrant/moodle/mod/hotpot/version.php') /vagrant/moodle/lib/classes/component.php:1105
```
