### PR TITLE
CONTRIB-5910: Disable control grade visibility to allow gradebook manage them

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -56,7 +56,6 @@ function hotpot_supports($feature) {
         'FEATURE_COMMENT'          => true,
         'FEATURE_COMPLETION_HAS_RULES' => false, // requires "hotpot_get_completion_state()"
         'FEATURE_COMPLETION_TRACKS_VIEWS' => true,
-        'FEATURE_CONTROLS_GRADE_VISIBILITY' => true,
         'FEATURE_GRADE_HAS_GRADE'  => true, // default=false
         'FEATURE_GRADE_OUTCOMES'   => true,
         'FEATURE_GROUPINGS'        => true, // default=false


### PR DESCRIPTION
Related to: https://tracker.moodle.org/browse/CONTRIB-5910

We have detected that HotPot activities has the feature FEATURE_CONTROLS_GRADE_VISIBILITY enabled but the code is not adapted to automatically manage the grade visibility.

In our case, we have some very old activities (before this feature) with hidden grades and we cannot show them, the gradebook cannot manage the visibility because of this feature and the module does not do it...

I think you should disable this feature in order to let the gradebook manage them.

The other way to make this work is to write the code to make the module manage this cases.
