### PR TITLE
Fix ORA-12899: value too large for MDL_HOTPOT_CACHE.SLASHARGUMENTS

### DIFF
--- a/attempt/renderer.php
+++ b/attempt/renderer.php
@@ -727,7 +727,11 @@ class mod_hotpot_attempt_renderer extends mod_hotpot_renderer {
 
         // transfer $CFG fields to cache record
         foreach ($this->cache_CFG_fields as $field) {
-            $this->cache->$field = trim($CFG->$field);
+            if (($field === 'slasharguments') && (!empty(trim($CFG->$field)))) {
+        		$this->cache->$field = '1';
+        	} else {
+                $this->cache->$field = trim($CFG->$field);
+            }
         }
 
         // transfer quiz fields to cache record


### PR DESCRIPTION
Seen in Moodle 3.1 with HotPot versions 2017021501 and 2017042707
When I try to upload a HotPot quiz, I get an error saying “Error writing to database”.
The problem is the slasharguments value is 18 chars (file.php/1/pic.jpg) and the database field only accepts length=1.  An alternate fix is to increase the DB field size.

```
[error]Default exception handler: Error writing to database Debug: ORA-12899: value too large for column "MOODLE"."M_HOTPOT_CACHE"."SLASHARGUMENTS" (actual: 18, maximum: 1)
INSERT INTO mdl_hotpot_cache (hotpotid,md5key,timemodified,slasharguments,hotpot_bodystyles,hotpot_enableobfuscate,hotpot_enableswf,name,sourcefile,sourcetype,sourcelocation,configfile,configlocation,navigation,stopbutton,stoptext,title,usefilters,useglossary,usemediafilter,studentfeedback,studentfeedbackurl,timelimit,delay3,clickreporting,sourcelastmodified,configlastmodified,sourceetag,configetag,sourcerepositoryid,configrepositoryid,content) VALUES (:hotpotid,:md5key,:timemodified,:slasharguments,:hotpot_bodystyles,:hotpot_enableobfuscate,:hotpot_enableswf,:name,:sourcefile,:sourcetype,:sourcelocation,:configfile,:configlocation,:navigation,:stopbutton,:stoptext,:title,:usefilters,:useglossary,:usemediafilter,:studentfeedback,:studentfeedbackurl,:timelimit,:delay3,:clickreporting,:sourcelastmodified,:configlastmodified,:sourceetag,:configetag,:sourcerepositoryid,:configrepositoryid,:content) RETURNING id INTO :oracle_id
[array (
  'hotpotid' => '3',
  'md5key' => '2755de56e7eb7a99a935df6c38457908',
  'timemodified' => 1430937011,
  'slasharguments' => 'file.php/1/pic.jpg',
  'hotpot_bodystyles' => '',
  'hotpot_enableobfuscate' => '1',
  'hotpot_enableswf' => '1',
  'name' => 'countries vs capital',
  'sourcefile' => '/countries and capital.jmt',
  'sourcetype' => 'hp_6_jmatch_xml',
  'sourcelocation' => '0',
  'configfile' => '',
  'configlocation' => '0',
  'navigation' => '1',
  'stopbutton' => '0',
  'stoptext' => '',
  'title' => '3',
  'usefilters' => '0',
  'useglossary' => '0',
  'usemediafilter' => '',
  'studentfeedback' => '0',
  'studentfeedbackurl' => '',
  'timelimit' => '0',
  'delay3' => '0',
  'clickreporting' => '0',
  'sourcelastmodified' => '',
  'configlastmodified' => '',
  'sourceetag' => '',
  'configetag' => '',
  'sourcerepositoryid' => 0,
  'configrepositoryid' => 0,
  'content' => 
  array (
    'clob' => 'Tzo4OiJzdGRDbGFzcyI6Nzp7czoxNDoieG1sZGVjbGFyYXRpb24iO3M6MjI6Ijw/eG1sIHZlcnNpb249IjEuMCI/PgoiO3M6NzoiZG9jdHlwZSI7czowOiIiO3M6MTQ6Imh0bWxhdHRyaWJ1dGVzIjtzOjA6IiI7czoxNDoiaGVhZGF0dHJpYnV0ZXMiO3M6MDoiIjtzOjExOiJoZWFkY29udGVudCI7czozNTU3OToiCjxsaW5rIHJlbD0ic2NoZW1hLkRDIiBocmVmPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIgLz4KPG1ldGEgbmFtZT0iREM6Q3JlYXRvciIgY29udGVudD0iVGVzdCIgLz4KPG1ldGEgbmFtZT0iREM6VGl0bGUiIGNvbnRlbnQ9ImNvdW50cmllcyB2cyBjYXBpdGFsIiAvPgo8bWV0YSBodHRwLWVxdWl2PSJDb250ZW50LVR5cGUiIGNvbnRlbnQ9InRleHQvaHRtbDsgY2hhcnNldD1pc28tODg1OS0xIiAvPgo8IS0tIE1hZGUgd2l0aCBleGVjdXRhYmxlIHZlcnNpb24gNi54IChNb29kbGUgMi43LjcrIChCdWlsZDogMjAxNTA0MjEpLCBIb3RQb3Qgbm8gcmVsZWFzZSBmb3VuZCkgLS0+CjwhLS0gVGhlIGZvbGxvd2luZyBpbnNlcnRpb24gYWxsb3dzIHlvdSB0byBhZGQgeW91ciBvd24gY29kZSBkaXJlY3RseSB0byB0aGlzIGhlYWQgdGFnIGZyb20gdGhlIGNvbmZpZ3VyYXRpb24gc2NyZWVuIC0tPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoqaHRtbCBvYmplY3QuTWVkaWFQbGF5ZXJOb3RGb3JJRQp7CglkaXNwbGF5OiBub25lOwp9CiNyZWdpb24tbWFpbiBwCnsKCXRleHQtYWxpZ246IGxlZnQ7CgltYXJnaW46IDBweDsKCWZvbnQtc2l6ZTogMTAwJTsKfQojcmVnaW9uLW1haW4gdGFibGUsCiNyZWdpb24tbWFpbiBkaXYsCiNyZWdpb24tbWFpbiBzcGFuLAojcmVnaW9uLW1haW4gdGQKewoJZm9udC1zaXplOiAxMDAlOwoJY29sb3I6ICMwMDAwMDA7Cn0KI3JlZ2lvbi1tYWluIGRpdi5UaXRsZXMKewoJcGFkZGluZzogMC41ZW07OwoJdGV4dC1hbGlnbjogY2VudGVyOwoJY29sb3I6ICMwMDAwMDA7Cn0KI3JlZ2lvbi1tYWluIGJ1dHRvbgp7Cglmb250LWZhbWlseTogR2VuZXZhLEFyaWFsLHNhbnMtc2VyaWY7Cglmb250LXNpemU6IDEwMCU7CglkaXNwbGF5OiBpbmxpbmU7Cn0KI3JlZ2lvbi1tYWluIC5FeGVyY2lzZVRpdGxlCnsKCWZvbnQtc2l6ZTogMTQwJTsKCWNvbG9yOiAjMDAwMDAwOwp9CiNyZWdpb24tbWFpbiAuRXhlcmNpc2VTdWJ0aXRsZQp7Cglmb250LXNpemU6IDEyMCU7Cgljb2xvcjogIzAwMDAwMDsKfQojcmVnaW9uLW1haW4gZGl2LlN0ZERpdgp7CgliYWNrZ3JvdW5kLWNvbG9yOiAjRkZGRkZGOwoJdGV4dC1hbGlnbjogY2VudGVyOwoJZm9udC1zaXplOiAxMDAlOwoJY29sb3I6ICMwMDAwMDA7CglwYWRkaW5nOiAwLjVlbTsKCWJvcmRlci1zdHlsZTogc29saWQ7Cglib3JkZXItd2lkdGg6IDFweCAxcHggMXB4IDFweDsKCWJvcmRlci1jb2xvcjogIzAwMDAwMDsKCW1hcmdpbi1ib3R0b206IDFweDsKfQojcmVnaW9uLW1haW4gLlJUTFRleHQKewoJdGV4dC1
```