### PR TITLE
Added support for block_myoverview in Moodle 3.3+

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -105,8 +105,10 @@ function hotpot_add_instance(stdclass $data, $mform) {
     // update gradebook item
     hotpot_grade_item_update($data);
 
-    $completiontimeexpected = !empty($data->completionexpected) ? $data->completionexpected : null;
-    \core_completion\api::update_completion_date_event($data->coursemodule, 'hotpot', $data->id, $completiontimeexpected);
+    if (class_exists('\core_completion\api')) {
+        $completiontimeexpected = (empty($data->completionexpected) ? null : $data->completionexpected);
+        \core_completion\api::update_completion_date_event($data->coursemodule, 'hotpot', $data->id, $completiontimeexpected);
+    }
 
     return $data->id;
 }

--- a/lib.php
+++ b/lib.php
@@ -140,8 +140,10 @@ function hotpot_update_instance(stdclass $data, $mform) {
         hotpot_update_grades($data);
     }
 
-    $completiontimeexpected = !empty($data->completionexpected) ? $data->completionexpected : null;
-    \core_completion\api::update_completion_date_event($data->coursemodule, 'hotpot', $data->id, $completiontimeexpected);
+    if (class_exists('\core_completion\api')) {
+        $completiontimeexpected = (empty($data->completionexpected) ? null : $data->completionexpected);
+        \core_completion\api::update_completion_date_event($data->coursemodule, 'hotpot', $data->id, $completiontimeexpected);
+    }
 
     return true;
 }

--- a/lib.php
+++ b/lib.php
@@ -105,6 +105,9 @@ function hotpot_add_instance(stdclass $data, $mform) {
     // update gradebook item
     hotpot_grade_item_update($data);
 
+    $completiontimeexpected = !empty($data->completionexpected) ? $data->completionexpected : null;
+    \core_completion\api::update_completion_date_event($data->coursemodule, 'hotpot', $data->id, $completiontimeexpected);
+
     return $data->id;
 }
 
@@ -134,6 +137,9 @@ function hotpot_update_instance(stdclass $data, $mform) {
         // recalculate grades for all users
         hotpot_update_grades($data);
     }
+
+    $completiontimeexpected = !empty($data->completionexpected) ? $data->completionexpected : null;
+    \core_completion\api::update_completion_date_event($data->coursemodule, 'hotpot', $data->id, $completiontimeexpected);
 
     return true;
 }
@@ -2283,5 +2289,35 @@ function hotpot_get_completion_state($course, $cm, $userid, $type) {
     }
 
     return $state;
+}
+
+/**
+ * This function receives a calendar event and returns the action associated with it, or null if there is none.
+ *
+ * This is used by block_myoverview in order to display the event appropriately. If null is returned then the event
+ * is not displayed on the block.
+ *
+ * @param calendar_event $event
+ * @param \core_calendar\action_factory $factory
+ * @return \core_calendar\local\event\entities\action_interface|null
+ */
+function mod_hotpot_core_calendar_provide_event_action(calendar_event $event,
+                                                            \core_calendar\action_factory $factory) {
+    $cm = get_fast_modinfo($event->courseid)->instances['hotpot'][$event->instance];
+
+    $completion = new \completion_info($cm->get_course());
+
+    $completiondata = $completion->get_data($cm, false);
+
+    if ($completiondata->completionstate != COMPLETION_INCOMPLETE) {
+        return null;
+    }
+
+    return $factory->create_instance(
+            get_string('view'),
+            new \moodle_url('/mod/hotpot/view.php', ['id' => $cm->id]),
+            1,
+            true
+    );
 }
 


### PR DESCRIPTION
cf. https://docs.moodle.org/dev/Calendar_API#Action_events

According to Moodle 3.3 documentation, the new Course Overview block displays notifications in My Page when a teacher sets an 'Expect completed on' date in the activity completion settings. This works will core modules and should work consistently with 3rd-party modules as well.

see https://docs.moodle.org/33/en/Course_overview 

The proposed changes would implement this in mod_hotpot