### PR TITLE
fix array_key_exists() type error in userfiltering.php

### DIFF
--- a/report/userfiltering.php
+++ b/report/userfiltering.php
@@ -410,7 +410,7 @@ class hotpot_filter_number extends user_filter_select {
         $field    = $this->_name;
         $operator = $field.'_op';
 
-        if (array_key_exists($field, $formdata) and !empty($formdata->$operator)) {
+        if (array_key_exists($field, (array) $formdata) and !empty($formdata->$operator)) {
             return array('operator' => (int)$formdata->$operator,
                          'value'    => (int)$formdata->$field);
         }


### PR DESCRIPTION
Hello,
I noticed that user filtering on the `Reports` page throws an exception with php 8:
```
Exception - array_key_exists(): Argument #2 ($array) must be of type array, stdClass given
Stack trace:
line 416 of /mod/hotpot/report/userfiltering.php: TypeError thrown
line 111 of /user/filters/lib.php: call to hotpot_filter_number->check_data()
line 184 of /mod/hotpot/report/renderer.php: call to user_filtering->__construct()
line 124 of /mod/hotpot/report/renderer.php: call to mod_hotpot_report_renderer->display_filters()
line 98 of /mod/hotpot/report/renderer.php: call to mod_hotpot_report_renderer->reportcontent()
line 93 of /mod/hotpot/report.php: call to mod_hotpot_report_renderer->render_report()
```

A quick fix done in this PR is to cast `$formdata` to an array in the function call. Alternatively, we could use `property_exists()`, which works with objects.